### PR TITLE
Fix the bower publish script

### DIFF
--- a/scripts/bower/publish.sh
+++ b/scripts/bower/publish.sh
@@ -45,7 +45,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     cp $BUILD_DIR/*.js .
 
     # updating bower.json
-    sed -i '' -e 's/"*\(version\)"*[ ]*:[ ]*"*.*"*/"\1": "'$NEW_VERSION'"/' bower.json
+    sed -i '' -e 's/"*\(version\)"*[ ]*:[ ]*"*.*"*/"\1": "'$NEW_VERSION'",/' bower.json
 
     # adding all changed files
     git add -A


### PR DESCRIPTION
The publish.sh script forgot to put a `,` after the version, making bower.json invalid.
